### PR TITLE
Check if path is valid before adding application path.

### DIFF
--- a/FCFileManager/FCFileManager.m
+++ b/FCFileManager/FCFileManager.m
@@ -66,6 +66,11 @@
 {
     [self assertPath:path];
     
+    BOOL exists = [[NSFileManager defaultManager] fileExistsAtPath:path];
+    // If path is already absolute, just return it.
+    if(exists)
+        return path;
+    
     NSString *defaultDirectory = [self absoluteDirectoryForPath:path];
     
     if(defaultDirectory != nil)


### PR DESCRIPTION
If path is already valid, we should not prepend the application path.