### PR TITLE
Hide sys/xattr.h from header as it causes cocoa pods to fail making framework

### DIFF
--- a/FCFileManager/FCFileManager.h
+++ b/FCFileManager/FCFileManager.h
@@ -7,7 +7,6 @@
 
 #import <Foundation/Foundation.h>
 #import <ImageIO/ImageIO.h>
-#import <sys/xattr.h>
 #import <UIKit/UIKit.h>
 
 @interface FCFileManager : NSObject

--- a/FCFileManager/FCFileManager.m
+++ b/FCFileManager/FCFileManager.m
@@ -6,6 +6,7 @@
 //
 
 #import "FCFileManager.h"
+#import <sys/xattr.h>
 
 @implementation FCFileManager
 


### PR DESCRIPTION
Publicize <sys/xattr.h> in the header causes CocoaPods  to fail building framework. Referred in https://github.com/fabiocaccamo/FCFileManager/issues/15 