### PR TITLE
fixed incorrect behavior in listFilesInDirectoryAtPath:withPrefix method

### DIFF
--- a/FCFileManager/FCFileManager.m
+++ b/FCFileManager/FCFileManager.m
@@ -424,8 +424,9 @@
     return [subpaths filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {
 
         NSString *subpath = (NSString *)evaluatedObject;
-
-        return ([subpath hasPrefix:prefix] || [subpath isEqualToString:prefix]);
+        NSString *fileName = [subpath lastPathComponent];
+        
+        return ([fileName hasPrefix:prefix] || [fileName isEqualToString:prefix]);
     }]];
 }
 


### PR DESCRIPTION
Why create this pull request:

For example, in my sandbox have some files

```
/var/mobile/Containers/Data/Application/xxx/Library/Caches/12319b12fd7726f240f04bde3f6ead19.gif,
/var/mobile/Containers/Data/Application/xxx/Library/Caches/2823f243c990697c7ef854b14c6265dd.png
```
call the original method with a prefix `@"1"`, will get no object prefixed with `1`

because the original method filter with a _absolute path_, not a file name, if you want to get the correct result, you should use a prefix with `@"/var/mobile/Containers/Data/Application/xxx/Library/Caches/1"` not `@"1"`

with my implementation, I use the `subpath` to get the file name, and filter with the file name, then if you want to filter a dictionary's file with a prefix, you can only use a method prefix parameter with file's prefix, like this:

```
[FCFileManager listFilesInDirectoryAtPath:@"/var/mobile/Containers/Data/Application/xxx/Library/Caches/" withPrefix:@"1"];
```
